### PR TITLE
[Fix] Idiomatic use of Context (context "flows" through the programme):

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vendor
 go.sum
 .idea
 configs/config-test.json
+coverage.txt

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -8,7 +8,7 @@
 5. Code structure according to clean architecture style guides ```DONE```
 6. Code passes go vet, golint and race detector checks ```DONE```
 7. UTs ```DONE```
-8. Try to reach 100% of the test coverage ```More or less DONE```
+8. Try to reach 100% of the test coverage ```More or less DONE ~85%```
 9. Integration tests should start by docker-compose ```DONE```
 10. ```make run``` and ```make test``` presence ```DONE```
 
@@ -20,5 +20,5 @@
 ## TODO for the future
 * Create a message queue that will send notifications for the service administrator about subnet 
 addresses that look suspicious;
-* Add context to every critical section of the programme so that OS signals could be propagated 
-and properly handled;
+* ~~Add context to every critical section of the programme so that OS signals could be propagated 
+and properly handled;~~ `DONE`

--- a/internal/domain/bucket/entity/bucket.go
+++ b/internal/domain/bucket/entity/bucket.go
@@ -4,46 +4,42 @@ import (
 	"context"
 	"log"
 	"sync"
-	"time"
 )
 
 // Bucket is a structure that represents a bucket object
 type Bucket struct {
-	count  int
-	name   string
-	mutex  sync.RWMutex
-	ctx    context.Context
-	cancel context.CancelFunc
+	count int
+	name  string
+	mutex sync.RWMutex
+	stop  chan struct{}
 }
 
 // NewBucket returns an new bucket object to the callee
-func NewBucket(ctxParent context.Context, name string, count int, expires time.Duration, done chan<- string) *Bucket {
-	// We create a context for each bucket to handle the removal of buckets by calling the cancel() function
-	innerCtx, cancel := context.WithCancel(ctxParent)
+func NewBucket(ctx context.Context, name string, count int, done chan<- string) *Bucket {
+	stopChan := make(chan struct{})
 	// We make sure that the bucket gets deleted after a certain time
-	go func(ctxInn context.Context, expire time.Duration) {
-		clickClick := time.NewTicker(expire)
+	go func(ctx context.Context, stopCh <-chan struct{}) {
 		select {
-		case <-ctxInn.Done():
-			if ctxInn.Err() == context.Canceled {
+		case <-ctx.Done():
+			// Time's up, a bucket has to die
+			if ctx.Err() == context.DeadlineExceeded {
+				done <- name
 				return
 			}
-			// Log unexpected error
-			log.Println(ctxInn.Err())
+			// Log other errors
+			log.Println(ctx.Err())
 			return
-		case <-clickClick.C:
-			// Boom!
+		case <-stopCh:
 			done <- name
 			return
 		}
-	}(innerCtx, expires)
+	}(ctx, stopChan)
 
 	return &Bucket{
-		name:   name,
-		count:  count,
-		mutex:  sync.RWMutex{},
-		ctx:    innerCtx,
-		cancel: cancel,
+		name:  name,
+		count: count,
+		mutex: sync.RWMutex{},
+		stop:  stopChan,
 	}
 }
 
@@ -60,7 +56,7 @@ func (b *Bucket) Decrement() bool {
 
 // Stop releases all the resources associated with the bucket
 func (b *Bucket) Stop() {
-	b.cancel()
+	b.stop <- struct{}{}
 }
 
 func (b *Bucket) checkAvailable() bool {


### PR DESCRIPTION
1) Removed context declarations from both Manager and Bucket objects;
2) Added a stop channel to the Bucket struct to replace cancel() call;
3) Adjusted UTs.